### PR TITLE
Removing calling location services enabled

### DIFF
--- a/Source/PermissionTypes/LocationWhenInUse.swift
+++ b/Source/PermissionTypes/LocationWhenInUse.swift
@@ -27,8 +27,12 @@ import CoreLocation
 
 internal extension Permission {
     var statusLocationWhenInUse: PermissionStatus {
-        guard CLLocationManager.locationServicesEnabled() else { return .disabled }
-        
+        // Calling this method on the main thread caused UI unresponsiveness.
+        // Because `CLLocationManager.authorizationStatus()` was returned `.denied` and was treated
+        // the same as `.disabled`, we're simply removing this method.
+
+        // guard CLLocationManager.locationServicesEnabled() else { return .disabled }
+
         let status = CLLocationManager.authorizationStatus()
         
         switch status {


### PR DESCRIPTION
Calling this method in the main thread is calling UI unresponsiveness.
Simply by calling `authorizationStatus()` we get a `.denied` status which produces the same outcome.